### PR TITLE
gh-227 Corrected secret name in update-gaffer-version workflow

### DIFF
--- a/.github/workflows/update-gaffer-version.yml
+++ b/.github/workflows/update-gaffer-version.yml
@@ -38,4 +38,4 @@ jobs:
       with:
         source_branch: ${{ env.VERSION_UPDATE_BRANCH }}
         destination_branch: master
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.ADMIN_GITHUB_TOKEN }}


### PR DESCRIPTION
Should allow for the PR to have tests run against it

# Related Issue

- Resolve #227