### PR TITLE
Gh-394: Add Javadoc page

### DIFF
--- a/docs/reference/javadoc.md
+++ b/docs/reference/javadoc.md
@@ -1,0 +1,12 @@
+# Gaffer Javadoc
+
+Gaffer is primarily written in Java so all of the operations and functions
+available stem from a Java class. As such, there are extensive generated
+Javadocs to aid with the understanding and usage of these classes and their
+associated methods.
+
+The Javadocs can be browsed via the window below or via the [hosted site.](http://gchq.github.io/Gaffer/overview-summary.html)
+
+<iframe src="http://gchq.github.io/Gaffer/overview-summary.html"
+        height="700"
+        style="display: flex; width: 100%; border: none;"></iframe>

--- a/docs/reference/javadoc.md
+++ b/docs/reference/javadoc.md
@@ -1,3 +1,8 @@
+---
+hide:
+  - toc
+---
+
 # Gaffer Javadoc
 
 Gaffer is primarily written in Java so all of the operations and functions


### PR DESCRIPTION
Simple page on the Javadocs for Gaffer, wrapped them in an `iframe` and provided a link too. Did look at using just a plain html `object` but seems overall an `iframe` is a better choice for this also tweaked the styling so the width should be dynamic to the page.

# Related Issue

- Resolve #394