### PR TITLE
Gh-397: Add getting started info to dev guide

### DIFF
--- a/docs/development-guide/introduction.md
+++ b/docs/development-guide/introduction.md
@@ -1,7 +1,7 @@
 # Development
 
 This development guide will take you through the steps required to start development work with Gaffer.
-This guide is not for end users of Gaffer, but is instead targeted at those who wish to develop Gaffer.
+This guide is not for end users of Gaffer and is instead targeted at those who wish to develop Gaffer.
 
 ## Source Control
 
@@ -23,7 +23,7 @@ These include:
 - `performance-testing` - Methods of testing the performance of ingest and query operations against a graph
 - `random-element-generation` - Code to generate large volumes of random graph data
 
-The [Gaffer docker repo](https://github.com/gchq/gaffer-docker) contains teh code needed to run Gaffer using Docker or Kubernetes. 
+The [Gaffer docker repo](https://github.com/gchq/gaffer-docker) contains the code needed to run Gaffer using Docker or Kubernetes. 
 More information about running a containerised instance of Gaffer can be found in our [adminstration guide](../administration-guide/introduction.md).
 
 It is also worth noting the [koryphe repo](https://github.com/gchq/koryphe) as this is a key dependency for Gaffer.

--- a/docs/development-guide/introduction.md
+++ b/docs/development-guide/introduction.md
@@ -1,8 +1,7 @@
 # Development
 
-!!! info "Work in Progress"
-
-    This page is under construction. To propose additions or changes, please use the pencil button above on the right.
+This development guide will take you through the steps required to start development work with Gaffer.
+This guide is not for end users of Gaffer, but is instead targeted at those who wish to develop Gaffer.
 
 ## Source Control
 
@@ -10,6 +9,25 @@ Development of Gaffer is done on the
 [GCHQ/Gaffer](https://github.com/gchq/Gaffer) GitHub repository, or other Gaffer
 GitHub repositories under the [GCHQ
 Organization](https://github.com/orgs/gchq/repositories).
+
+## Repositories
+
+The [Gaffer core repo](https://github.com/gchq/Gaffer) contains the main Gaffer product. 
+If you are completely new to Gaffer you can try out our [Road Traffic Demo](https://github.com/gchq/Gaffer/blob/master/example/road-traffic/README.md) or look at our example [deployment guide](../development-guide/example-deployment/project-setup.md).
+
+The [gaffer-tools repo](https://github.com/gchq/gaffer-tools) contains a number of useful tools that assist in working with Gaffer. 
+These include:
+
+- `gafferpy` - Allows operations against a graph to be executed from a Python shell
+- `mini-accumulo-cluster` - Allows a mini Accumulo cluster to be spun up for testing purposes
+- `performance-testing` - Methods of testing the performance of ingest and query operations against a graph
+- `random-element-generation` - Code to generate large volumes of random graph data
+
+The [Gaffer docker repo](https://github.com/gchq/gaffer-docker) contains teh code needed to run Gaffer using Docker or Kubernetes. 
+More information about running a containerised instance of Gaffer can be found in our [adminstration guide](../administration-guide/introduction.md).
+
+It is also worth noting the [koryphe repo](https://github.com/gchq/koryphe) as this is a key dependency for Gaffer.
+It contains an extensible functions library for filtering, aggregating and transforming data based on the Java Function API. 
 
 ## Building Gaffer
 

--- a/docs/development-guide/introduction.md
+++ b/docs/development-guide/introduction.md
@@ -1,7 +1,7 @@
 # Development
 
 This development guide will take you through the steps required to start development work with Gaffer.
-This guide is not for end users of Gaffer and is instead targeted at those who wish to develop Gaffer.
+This guide is not for end users of Gaffer and is instead targeted at those who wish to develop Gaffer or build Gaffer extensions.
 
 ## Source Control
 


### PR DESCRIPTION
Additional links and information added to the Developer Guide introduction page to assist those looking to start developing Gaffer. 

# Related Issue

- Resolve #397