### PR TITLE
Gh-172: Document the Job Tracker

### DIFF
--- a/docs/administration-guide/job-tracker.md
+++ b/docs/administration-guide/job-tracker.md
@@ -26,7 +26,7 @@ Note that this is not the same as your initial cache, as this results 'cache' is
 which will store your results.
 
 To store results using the job tracker a few elements must be set up. 
-Firstly, you need to add two operations to an [operations declarations JSON file](../development-guide/example-deployment/project-setup.md#operations-declarations). 
+Firstly, you need to add two operations to an [operations declarations JSON file](../administration-guide/gaffer-config/config.md#operationsdeclarationsjson). 
 These operations are [`ExportToGafferResultCache` and `GetGafferResultCacheExport`](../reference/operations-guide/export.md#exporttogafferresultcache).
 Together these allow you to store your results in a seperate Gaffer graph, your 'cache'.
 

--- a/docs/administration-guide/job-tracker.md
+++ b/docs/administration-guide/job-tracker.md
@@ -14,19 +14,20 @@ while a 'cache' is used to store any job results.
 ## Configuration
 
 By default, the job tracker is disabled. 
-It can be enabled by setting its associated [store property](../administration-guide/gaffer-stores/store-guide.md/#cache-service) to true.
-There must also be a [cache configured](../administration-guide/gaffer-stores/store-guide.md/#caches) for the job
+It can be enabled by setting its associated [store property](../administration-guide/gaffer-stores/store-guide#store-properties) to true.
+There must also be a [cache configured](../administration-guide/gaffer-stores/store-guide.md#caches) for the job
 tracker to work.
 
+### Configuring the Results Cache
 To store any results using the job tracker, a `GafferResultCache` needs to enabled. 
 This job results cache can then store your results using operations and operation handlers 
 (these are disabled by default). 
-Note that this is note the same as your initial cache, as this results 'cache' is simply a second Gaffer graph
-which will hold any results.
+Note that this is not the same as your initial cache, as this results 'cache' is simply a second Gaffer graph
+which will store your results.
 
 To store results using the job tracker a few elements must be set up. 
-Firstly, you need to add two operations to an [operations declarations JSON file](../development-guide/example-deployment/project-setup.md/#operations-declarations). 
-These operations are [`ExportToGafferResultCache` and `GetGafferResultCacheExport`](../reference/operations-guide/export.md/#exporttogafferresultcache).
+Firstly, you need to add two operations to an [operations declarations JSON file](../development-guide/example-deployment/project-setup.md#operations-declarations). 
+These operations are [`ExportToGafferResultCache` and `GetGafferResultCacheExport`](../reference/operations-guide/export.md#exporttogafferresultcache).
 Together these allow you to store your results in a seperate Gaffer graph, your 'cache'.
 
 !!! example "Adding the operations to your Operations Declarations file"
@@ -56,8 +57,8 @@ Together these allow you to store your results in a seperate Gaffer graph, your 
     }
     ```
 
-As the results 'cache' is a separate Gaffer graph; an additional `cache-store.properties` file will need to be created
-which contains the properties for your results graph. 
+As the results 'cache' is a separate Gaffer graph; an additional `cache-store.properties` file must be created
+to configure store the properties for your results graph. 
 This could be a MapStore or a separate table in your Accumulo cluster. 
 The `storePropertiesPath` in your Operation Declarations JSON file is a path to this second store properties file
 which then allows the operation handlers to store results in the second graph.
@@ -71,7 +72,7 @@ Additionally, there are 5 endpoints in the REST API that can be used to manage J
 
 ### Get Jobs
 
-In addition to the [GetAllJobDetails operation](../reference/operations-guide/job.md/#getalljobdetails) there
+In addition to the [GetAllJobDetails operation](../reference/operations-guide/job.md#getalljobdetails) there
 is an endpoint that gets the details of all asynchronous jobs.
 This endpoint is simply `/rest/graph/jobs` and takes no parameters. 
 
@@ -105,7 +106,7 @@ and one for getting the results of a job.
 `/rest/graph/jobs/{id}` can be used to get the details of a single job
 using that job's id. 
 When making a request to this endpoint you must specify the job id you want the details of,
-similar to the [GetJobDetails operation](../reference/operations-guide/job.md/#getjobdetails).
+similar to the [GetJobDetails operation](../reference/operations-guide/job.md#getjobdetails).
 
 The `/rest/graph/jobs/{id}/results` endpoint is similar as it also 
 requires a specific job id to return a specific job's results from the cache. 

--- a/docs/administration-guide/job-tracker.md
+++ b/docs/administration-guide/job-tracker.md
@@ -58,7 +58,7 @@ Together these allow you to store your results in a seperate Gaffer graph, your 
     ```
 
 As the results 'cache' is a separate Gaffer graph; an additional `cache-store.properties` file must be created
-to configure store the properties for your results graph. 
+to configure the store properties for your results graph. 
 This could be a MapStore or a separate table in your Accumulo cluster. 
 The `storePropertiesPath` in your Operation Declarations JSON file is a path to this second store properties file
 which then allows the operation handlers to store results in the second graph.

--- a/docs/administration-guide/job-tracker.md
+++ b/docs/administration-guide/job-tracker.md
@@ -1,0 +1,138 @@
+# Job Tracker
+
+This section covers how to configure your Gaffer graph to allow jobs to be executed.
+
+'Job' refers to an operation chain with a long-running sequence of operations that is executed
+asynchronously. 
+Jobs are, therefore, useful for operation chains which take a long time to return results or if 
+you want to cache the results of your operation chain. 
+
+Jobs are only available when the job tracker has been enabled. 
+The job tracker can then be used to store the status of current and historic jobs 
+while a 'cache' is used to store any job results. 
+
+## Configuration
+
+By default, the job tracker is disabled. 
+It can be enabled by setting its associated [store property](../administration-guide/gaffer-stores/store-guide.md/#cache-service) to true.
+There must also be a [cache configured](../administration-guide/gaffer-stores/store-guide.md/#caches) for the job
+tracker to work.
+
+To store any results using the job tracker, a `GafferResultCache` needs to enabled. 
+This job results cache can then store your results using operations and operation handlers 
+(these are disabled by default). 
+Note that this is note the same as your initial cache, as this results 'cache' is simply a second Gaffer graph
+which will hold any results.
+
+To store results using the job tracker a few elements must be set up. 
+Firstly, you need to add two operations to an [operations declarations JSON file](../development-guide/example-deployment/project-setup.md/#operations-declarations). 
+These operations are [`ExportToGafferResultCache` and `GetGafferResultCacheExport`](../reference/operations-guide/export.md/#exporttogafferresultcache).
+Together these allow you to store your results in a seperate Gaffer graph, your 'cache'.
+
+!!! example "Adding the operations to your Operations Declarations file"
+    
+    ``` json
+    {
+        "operations": [
+            {
+                "operation": "uk.gov.gchq.gaffer.operation.impl.export.resultcache.ExportToGafferResultCache",
+                "handler": {
+                    "class": "uk.gov.gchq.gaffer.operation.export.resultcache.handler.ExportToGafferResultCacheHandler",
+                    "graphId": "resultCacheGraph",
+                    "timeToLive": 86400000,
+                    "storePropertiesPath": "cache-store.properties"
+                }
+            },
+            {
+                "operation": "uk.gov.gchq.gaffer.operation.impl.export.resultcache.GetGafferResultCacheExport",
+                "handler": {
+                    "class": "uk.gov.gchq.gaffer.operation.export.resultcache.handler.GetGafferResultCacheExportHandler",
+                    "graphId": "resultCacheGraph",
+                    "timeToLive": 86400000,
+                    "storePropertiesPath": "cache-store.properties"
+                }
+            }
+        ]
+    }
+    ```
+
+As the results 'cache' is a separate Gaffer graph; an additional `cache-store.properties` file will need to be created
+which contains the properties for your results graph. 
+This could be a MapStore or a separate table in your Accumulo cluster. 
+The `storePropertiesPath` in your Operation Declarations JSON file is a path to this second store properties file
+which then allows the operation handlers to store results in the second graph.
+
+## Using Jobs 
+
+Once configured, there are [several operations](../reference/operations-guide/job.md) available
+to manage Jobs. 
+
+Additionally, there are 5 endpoints in the REST API that can be used to manage Jobs. 
+
+### Get Jobs
+
+In addition to the [GetAllJobDetails operation](../reference/operations-guide/job.md/#getalljobdetails) there
+is an endpoint that gets the details of all asynchronous jobs.
+This endpoint is simply `/rest/graph/jobs` and takes no parameters. 
+
+### Execute a Job 
+
+There is the `/rest/graph/jobs` POST endpoint which can be used to schedule an asynchronous job.
+This endpoint takes an operation, this is either in the form of a single operation, an Operation Chain
+stored as a variable and then passed to the endpoint or a Named Operation.
+
+Additionally, you can execute a job using the Java, this requires a user to be configured.
+
+??? example "Execute a job"
+    ```java
+    final User user = new User("user01");
+
+    OperationChain<Long> operation = new OperationChain.Builder()
+        .first(new GetElements.Builder().input(new EntitySeed("v1")).build())
+        .then(new Count<>())
+        .build();
+
+    final Job job = graph.execute(operation, user);
+    ```
+
+When you execute a job the details of that job will be returned.
+
+### Retrieving Job Details and Results
+
+There are two more GET endpoints; one for getting the details of a job
+and one for getting the results of a job.
+
+`/rest/graph/jobs/{id}` can be used to get the details of a single job
+using that job's id. 
+When making a request to this endpoint you must specify the job id you want the details of,
+similar to the [GetJobDetails operation](../reference/operations-guide/job.md/#getjobdetails).
+
+The `/rest/graph/jobs/{id}/results` endpoint is similar as it also 
+requires a specific job id to return a specific job's results from the cache. 
+
+### Schedule Jobs
+
+The final endpoint is another POST endpoint which can be used to schedule an 
+asynchronous job to run at a specified timepoint(s). 
+
+??? example "Example of a job being scheduled"
+
+    === "Java"
+        ``` java
+        final Job job = new Job(new Repeat(20L, 30L, TimeUnit.SECONDS), new GetAllElements());
+        ```
+
+    === "JSON"
+    Currently this can only be executed at the /graph/jobs/schedule endpoint.
+        ``` json
+        {
+            "repeat": {
+                "initialDelay": 20,
+                "repeatPeriod": 30,
+                "timeUnit": "SECONDS"
+            },
+            "operation":{
+                "class": "uk.gov.gchq.gaffer.operation.impl.get.GetAllElements"
+            }
+        }
+        ```

--- a/docs/reference/operations-guide/job.md
+++ b/docs/reference/operations-guide/job.md
@@ -30,7 +30,7 @@ Gets all running and historic job details for the graph. [Javadoc](https://gchq.
 
         ``` json
         {
-        "class" : "GetAllJobDetails"
+            "class" : "GetAllJobDetails"
         }
         ```
 
@@ -52,15 +52,15 @@ Gets all running and historic job details for the graph. [Javadoc](https://gchq.
 
         ``` json
         [ {
-        "jobId" : "b7084ad3-68ab-4a7b-879c-4c71813ac66f",
-        "user" : {
-            "userId" : "user01",
-            "dataAuths" : [ ],
-            "opAuths" : [ ]
-        },
-        "status" : "RUNNING",
-        "startTime" : 1667818802286,
-        "opChain" : "OperationChain[GetAllJobDetails]"
+            "jobId" : "b7084ad3-68ab-4a7b-879c-4c71813ac66f",
+            "user" : {
+                "userId" : "user01",
+                "dataAuths" : [ ],
+                "opAuths" : [ ]
+            },
+            "status" : "RUNNING",
+            "startTime" : 1667818802286,
+            "opChain" : "OperationChain[GetAllJobDetails]"
         } ]
         ```
 
@@ -84,14 +84,14 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` json
         {
-        "class" : "OperationChain",
-        "operations" : [ {
-            "class" : "GetAllElements"
-        }, {
-            "class" : "DiscardOutput"
-        }, {
-            "class" : "GetJobDetails"
-        } ]
+            "class" : "OperationChain",
+            "operations" : [ {
+                "class" : "GetAllElements"
+            }, {
+                "class" : "DiscardOutput"
+            }, {
+                "class" : "GetJobDetails"
+            } ]
         }
         ```
 
@@ -99,11 +99,11 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` python
         g.OperationChain( 
-        operations=[ 
-            g.GetAllElements(), 
-            g.DiscardOutput(), 
-            g.GetJobDetails() 
-        ] 
+            operations=[ 
+                g.GetAllElements(), 
+                g.DiscardOutput(), 
+                g.GetJobDetails() 
+            ] 
         )
         ```
 
@@ -119,15 +119,15 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` json
         {
-        "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011",
-        "user" : {
-            "userId" : "user01",
-            "dataAuths" : [ ],
-            "opAuths" : [ ]
-        },
-        "status" : "RUNNING",
-        "startTime" : 1667818803505,
-        "opChain" : "OperationChain[GetAllElements->DiscardOutput->GetJobDetails]"
+            "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011",
+            "user" : {
+                "userId" : "user01",
+                "dataAuths" : [ ],
+                "opAuths" : [ ]
+            },
+            "status" : "RUNNING",
+            "startTime" : 1667818803505,
+            "opChain" : "OperationChain[GetAllElements->DiscardOutput->GetJobDetails]"
         }
         ```
 
@@ -145,8 +145,8 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` json
         {
-        "class" : "GetJobDetails",
-        "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011"
+            "class" : "GetJobDetails",
+            "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011"
         }
         ```
 
@@ -154,7 +154,7 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` python
         g.GetJobDetails( 
-        job_id="306e1208-62d2-47d5-b2c2-1005d3295011" 
+            job_id="306e1208-62d2-47d5-b2c2-1005d3295011" 
         )
         ```
 
@@ -170,16 +170,16 @@ Gets the details of a single job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov
 
         ``` json
         {
-        "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011",
-        "user" : {
-            "userId" : "user01",
-            "dataAuths" : [ ],
-            "opAuths" : [ ]
-        },
-        "status" : "FINISHED",
-        "startTime" : 1667818803505,
-        "endTime" : 1667818803505,
-        "opChain" : "OperationChain[GetAllElements->DiscardOutput->GetJobDetails]"
+            "jobId" : "306e1208-62d2-47d5-b2c2-1005d3295011",
+            "user" : {
+                "userId" : "user01",
+                "dataAuths" : [ ],
+                "opAuths" : [ ]
+            },
+            "status" : "FINISHED",
+            "startTime" : 1667818803505,
+            "endTime" : 1667818803505,
+            "opChain" : "OperationChain[GetAllElements->DiscardOutput->GetJobDetails]"
         }
         ```
 
@@ -201,8 +201,8 @@ Gets the results of a job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/g
 
         ``` json
         {
-        "class" : "GetJobResults",
-        "jobId" : "60d667eb-a20d-44c2-963f-fc1b6c9b3868"
+            "class" : "GetJobResults",
+            "jobId" : "60d667eb-a20d-44c2-963f-fc1b6c9b3868"
         }
         ```
 
@@ -210,7 +210,7 @@ Gets the results of a job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/g
 
         ``` python
         g.GetJobResults( 
-        job_id="60d667eb-a20d-44c2-963f-fc1b6c9b3868" 
+            job_id="60d667eb-a20d-44c2-963f-fc1b6c9b3868" 
         )
         ```
 
@@ -236,100 +236,100 @@ Gets the results of a job. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/g
 
         ``` json
         [ {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 1,
-        "destination" : 4,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 1
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 1,
+            "destination" : 4,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 1
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 2,
-        "destination" : 4,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 1
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 2,
+            "destination" : 4,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 1
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 1,
-        "destination" : 2,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 3
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 1,
+            "destination" : 2,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 3
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 2,
-        "destination" : 5,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 1
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 2,
+            "destination" : 5,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 1
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Entity",
-        "group" : "entity",
-        "vertex" : 5,
-        "properties" : {
-            "count" : 3
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Entity",
+            "group" : "entity",
+            "vertex" : 5,
+            "properties" : {
+                "count" : 3
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 3,
-        "destination" : 4,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 4
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 3,
+            "destination" : 4,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 4
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Entity",
-        "group" : "entity",
-        "vertex" : 1,
-        "properties" : {
-            "count" : 3
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Entity",
+            "group" : "entity",
+            "vertex" : 1,
+            "properties" : {
+                "count" : 3
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Edge",
-        "group" : "edge",
-        "source" : 2,
-        "destination" : 3,
-        "directed" : true,
-        "matchedVertex" : "SOURCE",
-        "properties" : {
-            "count" : 2
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Edge",
+            "group" : "edge",
+            "source" : 2,
+            "destination" : 3,
+            "directed" : true,
+            "matchedVertex" : "SOURCE",
+            "properties" : {
+                "count" : 2
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Entity",
-        "group" : "entity",
-        "vertex" : 3,
-        "properties" : {
-            "count" : 2
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Entity",
+            "group" : "entity",
+            "vertex" : 3,
+            "properties" : {
+                "count" : 2
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Entity",
-        "group" : "entity",
-        "vertex" : 2,
-        "properties" : {
-            "count" : 1
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Entity",
+            "group" : "entity",
+            "vertex" : 2,
+            "properties" : {
+                "count" : 1
+            }
         }, {
-        "class" : "uk.gov.gchq.gaffer.data.element.Entity",
-        "group" : "entity",
-        "vertex" : 4,
-        "properties" : {
-            "count" : 1
-        }
+            "class" : "uk.gov.gchq.gaffer.data.element.Entity",
+            "group" : "entity",
+            "vertex" : 4,
+            "properties" : {
+                "count" : 1
+            }
         } ]
         ```
 
@@ -351,11 +351,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` json
         {
-        "class" : "OperationChain",
-        "operations" : [ {
-            "class" : "GetJobDetails",
-            "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
-        } ]
+            "class" : "OperationChain",
+            "operations" : [ {
+                "class" : "GetJobDetails",
+                "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
+            } ]
         }
         ```
 
@@ -363,11 +363,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` python
         g.OperationChain( 
-        operations=[ 
-            g.GetJobDetails( 
-            job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
-            ) 
-        ] 
+            operations=[ 
+                g.GetJobDetails( 
+                job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
+                ) 
+            ] 
         )
         ```
 
@@ -383,21 +383,21 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` json
         {
-        "repeat" : {
-            "initialDelay" : 1,
-            "repeatPeriod" : 1,
-            "timeUnit" : "MINUTES"
-        },
-        "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f",
-        "user" : {
-            "userId" : "user01",
-            "dataAuths" : [ ],
-            "opAuths" : [ ]
-        },
-        "status" : "SCHEDULED_PARENT",
-        "startTime" : 1667818799343,
-        "endTime" : 1667818799344,
-        "opChain" : "OperationChain[GetAllElements]"
+            "repeat" : {
+                "initialDelay" : 1,
+                "repeatPeriod" : 1,
+                "timeUnit" : "MINUTES"
+            },
+            "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f",
+            "user" : {
+                "userId" : "user01",
+                "dataAuths" : [ ],
+                "opAuths" : [ ]
+            },
+            "status" : "SCHEDULED_PARENT",
+            "startTime" : 1667818799343,
+            "endTime" : 1667818799344,
+            "opChain" : "OperationChain[GetAllElements]"
         }
         ```
 
@@ -417,11 +417,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` json
         {
-        "class" : "OperationChain",
-        "operations" : [ {
-            "class" : "CancelScheduledJob",
-            "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
-        } ]
+            "class" : "OperationChain",
+            "operations" : [ {
+                "class" : "CancelScheduledJob",
+                "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
+            } ]
         }
         ```
 
@@ -429,11 +429,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` python
         g.OperationChain( 
-        operations=[ 
-            g.CancelScheduledJob( 
-            job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
-            ) 
-        ] 
+            operations=[ 
+                g.CancelScheduledJob( 
+                job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
+                ) 
+            ] 
         )
         ```
 
@@ -451,11 +451,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` json
         {
-        "class" : "OperationChain",
-        "operations" : [ {
-            "class" : "GetJobDetails",
-            "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
-        } ]
+            "class" : "OperationChain",
+            "operations" : [ {
+                "class" : "GetJobDetails",
+                "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f"
+            } ]
         }
         ```
 
@@ -463,11 +463,11 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` python
         g.OperationChain( 
-        operations=[ 
-            g.GetJobDetails( 
-            job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
-            ) 
-        ] 
+            operations=[ 
+                g.GetJobDetails( 
+                job_id="35c1bd84-1cd3-4609-8892-710e9d3c2d3f" 
+                ) 
+            ] 
         )
         ```
 
@@ -484,20 +484,20 @@ Cancels a scheduled job specified by the job id. [Javadoc](https://gchq.github.i
 
         ``` json
         {
-        "repeat" : {
-            "initialDelay" : 1,
-            "repeatPeriod" : 1,
-            "timeUnit" : "MINUTES"
-        },
-        "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f",
-        "user" : {
-            "userId" : "user01",
-            "dataAuths" : [ ],
-            "opAuths" : [ ]
-        },
-        "status" : "CANCELLED",
-        "startTime" : 1667818799343,
-        "endTime" : 1667818799344,
-        "opChain" : "OperationChain[GetAllElements]"
+            "repeat" : {
+                "initialDelay" : 1,
+                "repeatPeriod" : 1,
+                "timeUnit" : "MINUTES"
+            },
+            "jobId" : "35c1bd84-1cd3-4609-8892-710e9d3c2d3f",
+            "user" : {
+                "userId" : "user01",
+                "dataAuths" : [ ],
+                "opAuths" : [ ]
+            },
+            "status" : "CANCELLED",
+            "startTime" : 1667818799343,
+            "endTime" : 1667818799344,
+            "opChain" : "OperationChain[GetAllElements]"
         }
         ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
         - 'Ingest Example': 'administration-guide/aggregation/ingest-example.md'
       - 'Named Operations': 'administration-guide/named-operations.md'
       - 'Operation Score': 'administration-guide/operation-score.md'
+      - 'Job Tracker': 'administration-guide/job-tracker.md'
       - Security:
         - 'Security Guide': 'administration-guide/security/security-guide.md'
         - 'User Control': 'administration-guide/security/user-control.md'


### PR DESCRIPTION
Added a page that explains jobs, the job tracker as well as using the endpoints to schedule jobs, execute jobs and get details relating to any jobs. 

Also fixed some of the code indentation on the Job Operations page.