### PR TITLE
Gh-428: Document DeleteAllData Operation

### DIFF
--- a/docs/administration-guide/gaffer-stores/store-guide.md
+++ b/docs/administration-guide/gaffer-stores/store-guide.md
@@ -106,7 +106,7 @@ You could also set the default cache suffix to share everything and set a specif
 
 Some operations are not available by default and you will need to manually configure them.
 
-These customisable operations can be added to your Gaffer graph by providing config in one or more operation declaration JSON files.
+These customisable operations can be added to your Gaffer graph by providing config in one or more [operation declaration JSON files](../gaffer-config/config.md#operationsdeclarationsjson).
 
 ### Named Operations
 Named Operations depends on the Cache service being active at runtime. See [Caches](#caches) above for how to enable these.

--- a/docs/development-guide/project-structure/components/graph.md
+++ b/docs/development-guide/project-structure/components/graph.md
@@ -44,7 +44,7 @@ The `GraphConfig` can be configured with the following:
 
  - `graphId` - The `graphId` is a String field that uniquely identifies a `Graph`. When backed by a Store like Accumulo, this `graphId` is used as the name of the Accumulo table for the `Graph`.
  - `description` - a string describing the `Graph`.
- - `view` - The `Graph View` allows a graph to be configured to only returned a subset of Elements when any Operation is executed. For example if you want your `Graph` to only show data that has a count more than 10 you could add a View to every operation you execute, or you can use this `Graph View` to apply the filter once and it would be merged into to all Operation Views so users only ever see this particular view of the data.
+ - `view` - The `Graph View` allows a graph to be configured to only return a subset of Elements when any Operation is executed. For example if you want your `Graph` to only show data that has a count more than 10 you could add a View to every operation you execute, or you can use this `Graph View` to apply the filter once and it would be merged into to all Operation Views so users only ever see this particular view of the data.
  - `library` - This contains information about the `Schema` and `StoreProperties` to be used.
  - `hooks` - A list of `GraphHook`s that will be triggered before, after and on failure when operations are executed on the `Graph`. See [GraphHooks](#graph-hooks) for more information.
 

--- a/docs/reference/operations-guide/core.md
+++ b/docs/reference/operations-guide/core.md
@@ -4520,3 +4520,36 @@ Gets the traits of the current store. [Javadoc](https://gchq.github.io/Gaffer/uk
         ``` json
         [ "QUERY_AGGREGATION", "MATCHED_VERTEX", "TRANSFORMATION", "INGEST_AGGREGATION", "PRE_AGGREGATION_FILTERING", "POST_TRANSFORMATION_FILTERING", "POST_AGGREGATION_FILTERING" ]
         ```
+
+## DeleteAllData
+
+!!! warning
+    This operation is currently only implemented for Accumulo stores.
+    
+Deletes all retained data including deleting the graph. To use this operation, it must be enabled via an [operations declarations JSON](../../administration-guide/gaffer-config/config.md#operationsdeclarationsjson). [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/DeleteAllData.html)
+
+
+??? example "Example deleting all data"
+
+    === "Java"
+
+        ``` java
+        final DeleteAllData operation = new DeleteAllData()
+        ```
+
+    === "JSON"
+
+        ``` json
+        {
+          "class" : "DeleteAllData"
+        }
+        ```
+
+    === "Python"
+
+        ``` python
+        g.DeleteAllData()
+        ```
+
+Note this operation does not return any response.
+

--- a/docs/reference/operations-guide/core.md
+++ b/docs/reference/operations-guide/core.md
@@ -4528,6 +4528,18 @@ Gets the traits of the current store. [Javadoc](https://gchq.github.io/Gaffer/uk
     
 Deletes all retained data including deleting the graph. To use this operation, it must be enabled via an [operations declarations JSON](../../administration-guide/gaffer-config/config.md#operationsdeclarationsjson). [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/DeleteAllData.html)
 
+```json title="operationsDeclarations.json"
+{
+    "operations": [
+        {
+            "operation": "uk.gov.gchq.gaffer.store.operation.DeleteAllData",
+            "handler": {
+                "class": "uk.gov.gchq.gaffer.accumulostore.operation.handler.DeleteAllDataHandler"
+            }
+        }
+    ]
+}
+```
 
 ??? example "Example deleting all data"
 

--- a/docs/reference/operations-guide/core.md
+++ b/docs/reference/operations-guide/core.md
@@ -4526,7 +4526,11 @@ Gets the traits of the current store. [Javadoc](https://gchq.github.io/Gaffer/uk
 !!! warning
     This operation is currently only implemented for Accumulo stores.
     
-Deletes all retained data including deleting the graph. To use this operation, it must be enabled via an [operations declarations JSON](../../administration-guide/gaffer-config/config.md#operationsdeclarationsjson). [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/DeleteAllData.html)
+Deletes all retained data including deleting the graph. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/DeleteAllData.html)
+
+To use this operation, it must be enabled via an [operations declarations JSON](../../administration-guide/gaffer-config/config.md#operationsdeclarationsjson).
+
+Note this operation does not return any response.
 
 ```json title="operationsDeclarations.json"
 {
@@ -4563,5 +4567,4 @@ Deletes all retained data including deleting the graph. To use this operation, i
         g.DeleteAllData()
         ```
 
-Note this operation does not return any response.
 

--- a/docs/reference/operations-guide/operations.md
+++ b/docs/reference/operations-guide/operations.md
@@ -79,7 +79,7 @@ Operation | Type
 [`named.view.AddNamedView`](named.md#addnamedview) | Named
 [`named.view.DeleteNamedView`](named.md#deletenamedview) | Named
 [`named.view.GetAllNamedViews`](named.md#getallnamedviews) | Named
-`store.operation.DeleteAllData` | Store
+[`store.operation.DeleteAllData`](core.md#deletealldata) | Store
 [`store.operation.GetSchema`](core.md#getschema) | Store
 [`store.operation.GetTraits`](core.md#gettraits) | Store
 `store.operation.HasTrait` | Store


### PR DESCRIPTION
Adds DeleteAllData to Core Operations page with configuration and implementation examples.
Adds link to operations declarations to Store Guide page.

# Related Issue

- Resolve #428