### PR TITLE
Gh-503: Consolidate Operation Score documentation

### DIFF
--- a/docs/administration-guide/gaffer-stores/store-guide.md
+++ b/docs/administration-guide/gaffer-stores/store-guide.md
@@ -72,7 +72,7 @@ gaffer.cache.service.default.class=uk.gov.gchq.gaffer.cache.impl.HashMapCacheSer
 ```
 
 Both the JCS and Hazelcast caches require configuration files.
-In the case of a JCS file this is a [ccf file](https://commons.apache.org/proper/commons-jcs/BasicJCSConfiguration.html) 
+In the case of a JCS file this is a [ccf file](https://commons.apache.org/proper/commons-jcs/BasicJCSConfiguration.html)
 while for Hazelcast this is commonly a [XML/YAML file](https://docs.hazelcast.com/imdg/4.2/configuration/understanding-configuration#static-configuration).
 
 You should then specify the location of any configuration file(s) in your store.properties file as follows:
@@ -114,62 +114,4 @@ These customisable operations can be added to your Gaffer graph by providing con
 Named Operations depends on the Cache service being active at runtime. See [Caches](#caches) above for how to enable these.
 
 ### ScoreOperationChain
-
-Variables:
-
-- opScores - required map of operation scores. These are the operation score values.
-- authScores - required map of operation authorisation scores. These are the maximum scores allowed for a user with a given role.
-- scoreResolvers - required (if using NamedOperations) list of score resolvers. These map operation class to its respective score resolver.
-
-
-??? example "Example operation scores map"
-
-    ```json
-    { 
-      "opScores": {
-        "uk.gov.gchq.gaffer.operation.Operation": 1,
-        "uk.gov.gchq.gaffer.operation.impl.generate.GenerateObjects": 0,
-        "uk.gov.gchq.gaffer.operation.impl.get.GetAllElements": 3
-      }
-    }
-    ```
-
-??? example "Example operation authorisation scores map"
-
-    ```json
-    {
-      "authScores": {
-        "User": 4,
-        "EnhancedUser": 10,
-        "OtherUser": 6
-      }
-    }
-    ```
-
-??? example "Example operation declarations JSON file"
-
-    ```json
-    {
-      "operations": [
-        {
-          "operation": "uk.gov.gchq.gaffer.operation.impl.ScoreOperationChain",
-          "handler": {
-            "class": "uk.gov.gchq.gaffer.store.operation.handler.ScoreOperationChainHandler",
-            "opScores": {
-              "uk.gov.gchq.gaffer.operation.Operation": 2,
-              "uk.gov.gchq.gaffer.operation.impl.generate.GenerateObjects": 0
-            },
-            "authScores": {
-              "User": 4,
-              "EnhancedUser": 10
-            },
-            "scoreResolvers": {
-              "uk.gov.gchq.gaffer.named.operation.NamedOperation": {
-                "class": "uk.gov.gchq.gaffer.store.operation.resolver.named.NamedOperationScoreResolver"
-              }
-            }
-          }
-        }
-      ]
-    }
-    ```
+Operation scores determine whether a particular user has the required permissions to execute a given OperationChain. See [Operation Scores](../../administration-guide/operation-score.md) for how to enable and congifure these.

--- a/docs/administration-guide/operation-score.md
+++ b/docs/administration-guide/operation-score.md
@@ -2,7 +2,7 @@
 
 Operation Scores can be used to give an OperationChains and NamedOperations a "score" which can then be used to determine whether a particular user has the required permissions to execute a given OperationChain.
 
-These scores work on a credit-like system where user's configured "score" is the amount they can then spend on running an Operation/OperationChain. 
+These scores work on a credit-like system where user's configured "score" is the amount they can then spend on running an Operation/OperationChain.
 Users cannot spend more than their score and every time they run an Operation or OperationChain that has a configured "score" this will be 'subtracted' from their score 'credit'.
 
 ## Using Operation Scores
@@ -13,10 +13,12 @@ To use this Operation you need to configure an `OperationsDeclarations.json`.
 To configure this file you need to set the following handlers which configure how Operation Scores are used with a graph:
 
 - `opScores` - required map of operation scores. These are the operation score values.
-- `authScores` - required map of operation authorisation scores. These are the maximum scores allowed for a user with a given role. 
+- `authScores` - required map of operation authorisation scores. These are the maximum scores allowed for a user with a given role.
 - `scoreResolver` - maps the operation class to its respective [score resolver](#score-resolver).
 
-!!! example "Example OperationDeclarations.json for a NamedOperation"
+!!! example "Example OperationDeclarations.json"
+
+    The operation declarations file for registering the `ScoreOperationChain` operation looks like:
 
     ```json
     {
@@ -44,60 +46,7 @@ To configure this file you need to set the following handlers which configure ho
     }
     ```
 
-!!! example "Example ScoreOperationChain"
-
-    === "Java"
-        ``` java
-        final ScoreOperationChain scoreOpChain = new ScoreOperationChain.Builder()
-            .operationChain(new OperationChain.Builder()
-                    .first(new GetElements())
-                    .then(new NamedOperation.Builder<Element, Iterable<? extends Element>>()
-                            .name("namedOp")
-                            .build())
-                    .then(new Limit<>(3))
-                    .build())
-            .build();
-        ```
-
-    === "JSON"
-        ``` json
-        {
-            "class" : "ScoreOperationChain",
-            "operationChain" : {
-                "class" : "OperationChain",
-                "operations" : [ {
-                    "class" : "GetElements"
-                }, {
-                    "class" : "NamedOperation",
-                    "operationName" : "namedOp"
-                }, {
-                    "class" : "Limit",
-                    "resultLimit" : 3,
-                    "truncate" : true
-                } ]
-            }
-        }
-        ```
-
-    === "Python"
-        ``` python
-        g.ScoreOperationChain( 
-            operation_chain=g.OperationChain( 
-                operations=[ 
-                    g.GetElements(), 
-                    g.NamedOperation( 
-                        operation_name="namedOp" 
-                    ), 
-                    g.Limit( 
-                        result_limit=3, 
-                        truncate=True 
-                    ) 
-                ] 
-            ) 
-        )
-        ```
-
-For more examples of ScoreOperationChain refer to the [Misc Operations page in the Reference Guide](../reference/operations-guide/misc.md#scoreoperationchain).
+For examples of ScoreOperationChain refer to the [Misc Operations page in the Reference Guide](../reference/operations-guide/misc.md#scoreoperationchain).
 
 ## Score Resolver
 
@@ -107,21 +56,21 @@ In most cases, implementing the [`DefaultScoreResolver`](https://gchq.github.io/
 However, some operations require specific ways of calculating their score so will require the implementation of different scoreResolver handlers.
 
 In the case of NamedOperations, the [`NamedOperationScoreResolver`](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/resolver/named/NamedOperationScoreResolver.html) should be implemented in the OperationDeclarations.json.
-This will resolve the custom Operation Score for a provided NamedOperation by looking for it in the cache. 
+This will resolve the custom Operation Score for a provided NamedOperation by looking for it in the cache.
 
 If choosing to score your `If` Operation, then you should implement the [`IfScoreResolver`](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/resolver/IfScoreResolver.html).
 This will provide the score as the maximum of the operations that are used within the `If` operation, regardless of which operation is actually executed.
 
-The `While` Operation, if scored, will also require implementation of the specific [`WhileScoreResolver`](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/resolver/WhileScoreResolver.html). 
+The `While` Operation, if scored, will also require implementation of the specific [`WhileScoreResolver`](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/resolver/WhileScoreResolver.html).
 The score will be the maximum of the transform operation and the delegate operation, multiplied by the minimum of the configured number of max repeats vs the global maximum number of allowed repeats.
 This is simply because the number of actual repetitions is nondeterministic, therefore a "worst"-case scenario is considered.
 
 ## Operation Chain Limiters
 
-`OperationChainLimiter` is a [GraphHook](../development-guide/project-structure/components/graph.md#graph-hooks) that checks a user is authorised to execute an operation chain based on that user's maximum chain score and the configured score value for each operation in the chain. 
+`OperationChainLimiter` is a [GraphHook](../development-guide/project-structure/components/graph.md#graph-hooks) that checks a user is authorised to execute an operation chain based on that user's maximum chain score and the configured score value for each operation in the chain.
 If you wish to use the ScoreOperationChain operation and this graph hook, then both need to have the same score configuration.
 
-To use the `OperationChainLimiter` GraphHook then you will need to configure that GraphHook to use the a Score Resolver interface. 
+To use the `OperationChainLimiter` GraphHook then you will need to configure that GraphHook to use the a Score Resolver interface.
 The ScoreOperationChainDeclaration.json declares that a NamedOperation should be resolved using a [`NamedOperationScoreResolver`](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/store/operation/resolver/named/NamedOperationScoreResolver.html).
 This will then allow you to have custom scores for each NamedOperation.
 
@@ -129,7 +78,7 @@ If you have the `OperationChainLimiter` GraphHook configured then this score wil
 the hook to limit operation chains.
 
 !!! example "Example hook configuration"
-    
+
     [Configuration of the hook](../development-guide/project-structure/components/graph.md#graph-configuration) should look something like this and should be placed in your `graphConfig.json`.
 
     ``` json
@@ -145,41 +94,10 @@ the hook to limit operation chains.
             "User": 2,
             "SuperUser": 5
         },
-        "scoreResolvers": { 
+        "scoreResolvers": {
             "uk.gov.gchq.gaffer.named.operation.NamedOperation": {
                 "class": "uk.gov.gchq.gaffer.store.operation.resolver.named.NamedOperationScoreResolver"
             }
         }
-    }
-    ```
-
-!!! example "Example operation declarations file"
-    
-    As a result, the operation declarations file for registering the `ScoreOperationChain` operation would then look like:
-
-    ``` json
-    {
-        "operations": [
-            {
-                "operation": "uk.gov.gchq.gaffer.operation.impl.ScoreOperationChain",
-                "handler": {
-                    "opScores": {
-                        "uk.gov.gchq.gaffer.operation.Operation": 1,
-                        "uk.gov.gchq.gaffer.operation.impl.add.AddElements": 2,
-                        "uk.gov.gchq.gaffer.operation.impl.get.GetAllElements": 5,
-                        "uk.gov.gchq.gaffer.operation.impl.generate.GenerateObjects": 0
-                    },
-                    "authScores": {
-                        "User": 2,
-                        "SuperUser": 5
-                    },
-                    "scoreResolvers": {
-                        "uk.gov.gchq.gaffer.named.operation.NamedOperation": {
-                            "class": "uk.gov.gchq.gaffer.store.operation.resolver.named.NamedOperationScoreResolver"
-                        }
-                    }
-                }
-            }
-        ]
     }
     ```

--- a/docs/development-guide/project-structure/components/operation.md
+++ b/docs/development-guide/project-structure/components/operation.md
@@ -72,7 +72,7 @@ public static class Builder extends Operation.BaseBuilder<GetElements, Builder>
 ### Operation Scores
 
 For use with a `ScoreOperationChain`, some `Operation`s may require a custom way of calculating an associated score, therefore an implementation of the `ScoreResolver` interface may be required.
-There is a `DefaultScoreResolver` to which the custom implementation should delegate, in a manner specific to the new Operation. For more info, see [ScoreOperationChain](../../../administration-guide/gaffer-stores/store-guide.md#scoreoperationchain) and [ScoreOperationChainExample](../../../reference/operations-guide/misc.md#scoreoperationchain).
+For more info, see the [Operation Score guide](../../../administration-guide/operation-score.md).
 
 ### Documentation
 

--- a/docs/reference/operations-guide/misc.md
+++ b/docs/reference/operations-guide/misc.md
@@ -49,7 +49,7 @@ Gets data from an endpoint. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/
 
 Determines a "score" for an OperationChain. This is used to determine whether a particular user has the required permissions to execute a given OperationChain. [Javadoc](https://gchq.github.io/Gaffer/uk/gov/gchq/gaffer/operation/impl/ScoreOperationChain.html)
 
-This operation requires Store configuration to be set before it can be used. See the [Store Guide](../../administration-guide/gaffer-stores/store-guide.md#scoreoperationchain) for how to do this.
+This operation requires Store configuration to be set before it can be used. See the [Operation Score Guide](../../administration-guide/operation-score.md) for how to do this.
 
 ### Example ScoreOperationChain
 


### PR DESCRIPTION
There was a lot of duplication regarding Operation Scores. Removed the duplicated code snippets and condensed into two main pages.

# Related issue

- Resolve #503