### PR TITLE
Gh-514: Additional View Documentation

### DIFF
--- a/docs/administration-guide/gaffer-stores/store-guide.md
+++ b/docs/administration-guide/gaffer-stores/store-guide.md
@@ -114,4 +114,4 @@ These customisable operations can be added to your Gaffer graph by providing con
 Named Operations depends on the Cache service being active at runtime. See [Caches](#caches) above for how to enable these.
 
 ### ScoreOperationChain
-Operation scores determine whether a particular user has the required permissions to execute a given OperationChain. See [Operation Scores](../../administration-guide/operation-score.md) for how to enable and congifure these.
+Operation scores determine whether a particular user has the required permissions to execute a given OperationChain. See [Operation Scores](../../administration-guide/operation-score.md) for how to enable and configure these.

--- a/docs/user-guide/query/gaffer-syntax/filtering.md
+++ b/docs/user-guide/query/gaffer-syntax/filtering.md
@@ -491,7 +491,7 @@ adding them to the view, e.g. `entity(getSchema().getEntityGroups())`.
         ```
 
 !!! warning
-    Users should not use this filter in conjunction with a `GetAdjacentIds` opeation as this
+    Users should not use this filter in conjunction with a `GetAdjacentIds` operation as this
     already only returns entities and results may not be returned correctly.
 
 ### Global View Definitions

--- a/docs/user-guide/query/gaffer-syntax/filtering.md
+++ b/docs/user-guide/query/gaffer-syntax/filtering.md
@@ -618,7 +618,8 @@ specific filters using an AND operator.
 
 !!! example ""
 
-    In this example this would get all `Commit` edges with a `weight` property
+    This example applies a global filter to both `Commit` edges
+    and `Person` entities to get all those with a `weight` property
     as well as all `Person` entities with an `age` property.
 
     === "Java"

--- a/docs/user-guide/query/gaffer-syntax/operations.md
+++ b/docs/user-guide/query/gaffer-syntax/operations.md
@@ -72,8 +72,8 @@ based on their ID. To do this we can use the `GetElements` operation and set the
     === "Python"
 
         ```python
-        elements = g_connector.execute_operation(
-            operation = gaffer.GetElements(input = [gaffer.EntitySeed(vertex = "v1")])
+        elements = gc.execute_operation(
+            operation = g.GetElements(input = [g.EntitySeed(vertex = "v1")])
         )
         ```
 
@@ -121,11 +121,11 @@ how many entities the `GetElements` returned.
     === "Python"
 
         ```python
-        count = g_connector.execute_operation_chain(
-            operation_chain = gaffer.OperationChain(
+        count = gc.execute_operation_chain(
+            operation_chain = g.OperationChain(
                 operations=[
-                    gaffer.GetElements(input = [gaffer.EntitySeed(vertex = "v1")]),
-                    gaffer.Count()
+                    g.GetElements(input = [g.EntitySeed(vertex = "v1")]),
+                    g.Count()
                 ]
             )
         )

--- a/docs/user-guide/query/gremlin/gremlin.md
+++ b/docs/user-guide/query/gremlin/gremlin.md
@@ -287,7 +287,7 @@ Users can run Named Operations and add new Named Operations, deleting Named Oper
 
         params = {"add": {"name": "CountAllElements", "opChain": operation}}
 
-        g.call("namedoperation", params).to_list()
+        g.call("namedoperation", params)
         ```
 
     === "Java"
@@ -307,7 +307,7 @@ Users can run Named Operations and add new Named Operations, deleting Named Oper
         addParams.put("opChain", operation.getOperationChainAsString());
         Map<String, Map <String, String>> params = Collections.singletonMap("add", addParams);
 
-        g.call("namedoperation", params).toList();
+        g.call("namedoperation", params);
         ```
 
 Users can also run any existing or added Named Operations that are stored in the cache.


### PR DESCRIPTION
Added missing docs on allEdges/allEntities and global view definitions. Also tidied up some inconsistencies in the Python snippets in the User guide and removed an unnecessary .to_list() in the Gremlin Named Ops section.

# Related issue

- Resolve #514